### PR TITLE
Add pHash printing during similarity checks

### DIFF
--- a/src/cleanvision/issue_managers/duplicate_issue_manager.py
+++ b/src/cleanvision/issue_managers/duplicate_issue_manager.py
@@ -47,6 +47,10 @@ def compute_hash(
     if image:
         for issue_type in to_compute:
             result[issue_type] = get_hash(image, params[issue_type])
+            if params[issue_type].get("hash_type") == "phash":
+                print(
+                    f"index: {index}, phash: {result[issue_type]}"
+                )
     return result
 
 


### PR DESCRIPTION
## Summary
- show each image's pHash when computing hashes for near-duplicate detection

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement setuptools>=43.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_688c7922d0588329a3fd27398d212196